### PR TITLE
fix OSM tiles from lyrk.org

### DIFF
--- a/whitelist.txt
+++ b/whitelist.txt
@@ -3,3 +3,4 @@ api.solvemedia.com
 *.github.com>*.github.com github.com>*.github.com *.github.com>github.com
 typekit.com *.typekit.com typekit.net *.typekit.net
 code.google.com>*.googlecode.com
+tiles.lyrk.org


### PR DESCRIPTION
Lyrk.org allows authentication via Referer instead of API keys to avoid others stealing API keys. I recommended them to instead block all requests with obviously wrong Referer (+API key), which still should discourage stealing API keys. Hopefully they’ll implement something like this, at which point the extra rule can be removed.