### PR TITLE
mark as multiprocessCompatible & bump maxVersion

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -14,7 +14,7 @@
 			<Description>
 				<em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
 				<em:minVersion>13.0</em:minVersion>
-				<em:maxVersion>22.0</em:maxVersion>
+				<em:maxVersion>51.0</em:maxVersion>
 			</Description>
 		</em:targetApplication>
 
@@ -22,11 +22,12 @@
 			<Description>
 				<em:id>{aa3c5121-dab2-40e2-81ca-7ea25febc110}</em:id>
 				<em:minVersion>13.0</em:minVersion>
-				<em:maxVersion>22.0</em:maxVersion>
+				<em:maxVersion>51.0</em:maxVersion>
 			</Description>
 		</em:targetApplication>
 
 		<em:type>2</em:type>
 		<em:bootstrap>true</em:bootstrap>
+		<em:multiprocessCompatible>true</em:multiprocessCompatible>
 	</Description>
 </RDF>


### PR DESCRIPTION
explicitly marking this as multiprocessCompatible so Firefox can enable multiprocess mode